### PR TITLE
Docs/update protocol parameters

### DIFF
--- a/docs/CIP/CIP-XXXX/messages/server/protocol-parameters.md
+++ b/docs/CIP/CIP-XXXX/messages/server/protocol-parameters.md
@@ -1,6 +1,7 @@
 # Protocol Parameter Server Message Partial
 
-This top level message key is added by the server as part of any synchronization process for every epoch boundary transition.
+This top level message key is added by the server as part of any synchronization process for every epoch boundary transition. 
+Protocol parameters sent as a raw cbor hex.
 
 > [!NOTE]
 > It is specific to the Cardano blockchain.
@@ -15,143 +16,13 @@ This top level message key is added by the server as part of any synchronization
     "epoch": {
       "type": "integer"
     },
-    "minFeeA": {
-      "type": "integer"
-    },
-    "minFeeB": {
-      "type": "integer"
-    },
-    "maxBlockSize": {
-      "type": "integer"
-    },
-    "maxTxSize": {
-      "type": "integer"
-    },
-    "maxBlockHeaderSize": {
-      "type": "integer"
-    },
-    "keyDeposit": {
-      "type": "string"
-    },
-    "poolDeposit": {
-      "type": "string"
-    },
-    "eMax": {
-      "type": "integer"
-    },
-    "nOpt": {
-      "type": "integer"
-    },
-    "a0": {
-      "type": "number"
-    },
-    "rho": {
-      "type": "number"
-    },
-    "tau": {
-      "type": "number"
-    },
-    "decentralisationParam": {
-      "type": "number"
-    },
-    "extraEntropy": {
-      "type": ["null", "string"]
-    },
-    "protocolMajorVer": {
-      "type": "integer"
-    },
-    "protocolMinorVer": {
-      "type": "integer"
-    },
-    "minUtxo": {
-      "type": "string"
-    },
-    "minPoolCost": {
-      "type": "string"
-    },
-    "nonce": {
-      "type": "string"
-    },
-    "costModels": {
-      "type": "object",
-      "properties": {
-        "plutusV1": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "integer"
-          }
-        },
-        "plutusV2": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "integer"
-          }
-        }
-      }
-    },
-    "priceMem": {
-      "type": "number"
-    },
-    "priceStep": {
-      "type": "number"
-    },
-    "maxTxExMem": {
-      "type": "string"
-    },
-    "maxTxExSteps": {
-      "type": "string"
-    },
-    "maxBlockExMem": {
-      "type": "string"
-    },
-    "maxBlockExSteps": {
-      "type": "string"
-    },
-    "maxValSize": {
-      "type": "string"
-    },
-    "collateralPercent": {
-      "type": "integer"
-    },
-    "maxCollateralInputs": {
-      "type": "integer"
-    },
-    "coinsPerUtxoSize": {
+    "parameters": {
       "type": "string"
     }
   },
   "required": [
     "epoch",
-    "minFeeA",
-    "minFeeB",
-    "maxBlockSize",
-    "maxTxSize",
-    "maxBlockHeaderSize",
-    "keyDeposit",
-    "poolDeposit",
-    "eMax",
-    "nOpt",
-    "a0",
-    "rho",
-    "tau",
-    "decentralisationParam",
-    "extraEntropy",
-    "protocolMajorVer",
-    "protocolMinorVer",
-    "minUtxo",
-    "minPoolCost",
-    "nonce",
-    "costModels",
-    "priceMem",
-    "priceStep",
-    "maxTxExMem",
-    "maxTxExSteps",
-    "maxBlockExMem",
-    "maxBlockExSteps",
-    "maxValSize",
-    "collateralPercent",
-    "maxCollateralInputs",
-    "coinsPerUtxoSize"
+    "parameters"
   ]
 }
 ```
@@ -162,45 +33,7 @@ This top level message key is added by the server as part of any synchronization
 {
   "protocolParameters": {
     "epoch": 225,
-    "minFeeA": 44,
-    "minFeeB": 155381,
-    "maxBlockSize": 65536,
-    "maxTxSize": 16384,
-    "maxBlockHeaderSize": 1100,
-    "keyDeposit": "2000000",
-    "poolDeposit": "500000000",
-    "eMax": 18,
-    "nOpt": 150,
-    "a0": 0.3,
-    "rho": 0.003,
-    "tau": 0.2,
-    "decentralisationParam": 0.5,
-    "extraEntropy": null,
-    "protocolMajorVer": 2,
-    "protocolMinorVer": 0,
-    "minUtxo": "1000000",
-    "minPoolCost": "340000000",
-    "nonce": "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81",
-    "costModels": {
-      "plutusV1": {
-        "addIntegerCpuArgumentsIntercept": 197209,
-        "addIntegerCpuArgumentsSlope": 0
-      },
-      "plutusV2": {
-        "addIntegerCpuArgumentsIntercept": 197209,
-        "addIntegerCpuArgumentsSlope": 0
-      }
-    },
-    "priceMem": 0.0577,
-    "priceStep": 0.0000721,
-    "maxTxExMem": "10000000",
-    "maxTxExSteps": "10000000000",
-    "maxBlockExMem": "50000000",
-    "maxBlockExSteps": "40000000000",
-    "maxValSize": "5000",
-    "collateralPercent": 150,
-    "maxCollateralInputs": 3,
-    "coinsPerUtxoSize": "34482"
+    "parameters": "cbor hex"
   }
 }
 ```

--- a/docs/CIP/CIP-XXXX/src/cardano-service.yml
+++ b/docs/CIP/CIP-XXXX/src/cardano-service.yml
@@ -399,10 +399,18 @@ components:
           type: string
         transactions:
           type: array
-          format: string
+          items:
+            type: string
+            contentEncoding: base16
+            description: "The raw serialized CBOR, as found on-chain."
         resolvedInputs:
           type: array
-          format: string
+          items:
+            type: array
+            items:
+              type: string
+              contentEncoding: base16
+              description: "The raw serialized CBOR, as found on-chain."
         point:
           type: object
           $ref: '#/components/schemas/pointPayload'

--- a/docs/CIP/CIP-XXXX/src/cardano-service.yml
+++ b/docs/CIP/CIP-XXXX/src/cardano-service.yml
@@ -315,6 +315,7 @@ components:
   schemas:
     welcomePayload:
       type: object
+      additionalProperties: false
       properties:
         blockchains:
           type: array
@@ -357,6 +358,7 @@ components:
         - blockchains
     genesisPayload:
       type: object
+      additionalProperties: false
       properties:
         activeSlotsCoefficient:
           type: number
@@ -392,6 +394,7 @@ components:
         - securityParam
     transactionPayload:
       type: object
+      additionalProperties: false
       properties:
         outputIndex:
           type: number
@@ -421,6 +424,7 @@ components:
           $ref: '#/components/schemas/pointPayload'
     pointPayload:
       type: object
+      additionalProperties: false
       properties:
         slot:
           type: integer
@@ -451,6 +455,7 @@ components:
         - parameters
     eraSummaryPayload:
       type: object
+      additionalProperties: false
       properties:
         parameters:
           type: object
@@ -479,6 +484,7 @@ components:
         - start
     subscribePayload:
       type: object
+      additionalProperties: false
       properties:
         type:
           type: string

--- a/docs/CIP/CIP-XXXX/src/cardano-service.yml
+++ b/docs/CIP/CIP-XXXX/src/cardano-service.yml
@@ -167,7 +167,7 @@ components:
         synchronization process for every epoch boundary transition.
       contentType: application/json
       payload:
-        $ref: '#/components/schemas/protocolParameterPayload'
+        $ref: '#/components/schemas/protocolParametersPayload'
       examples:
         -
           name: protocolParameters
@@ -429,110 +429,18 @@ components:
           $ref: '#/components/schemas/pointPayload'
       required:
         - point
-    protocolParameterPayload:
+    protocolParametersPayload:
       type: object
       properties:
         epoch:
           type: integer
-        minFeeA:
-          type: integer
-        minFeeB:
-          type: integer
-        maxBlockSize:
-          type: integer
-        maxTxSize:
-          type: integer
-        maxBlockHeaderSize:
-          type: integer
-        keyDeposit:
+        parameters:
           type: string
-        poolDeposit:
-          type: string
-        eMax:
-          type: integer
-        nOpt:
-          type: integer
-        a0:
-          type: number
-        rho:
-          type: number
-        tau:
-          type: number
-        decentralisationParam:
-          type: number
-        extraEntropy:
-          type:
-            - 'null'
-            - string
-        protocolMajorVer:
-          type: integer
-        protocolMinorVer:
-          type: integer
-        minUtxo:
-          type: string
-        minPoolCost:
-          type: string
-        nonce:
-          type: string
-        costModels:
-          type: object
-          properties:
-            plutusV1:
-              type: object
-            plutusV2:
-              type: object
-        priceMem:
-          type: number
-        priceStep:
-          type: number
-        maxTxExMem:
-          type: string
-        maxTxExSteps:
-          type: string
-        maxBlockExMem:
-          type: string
-        maxBlockExSteps:
-          type: string
-        maxValSize:
-          type: string
-        collateralPercent:
-          type: integer
-        maxCollateralInputs:
-          type: integer
-        coinsPerUtxoSize:
-          type: string
+          contentEncoding: base16
+          description: "The raw serialized CBOR, as found on-chain."
       required:
         - epoch
-        - minFeeA
-        - minFeeB
-        - maxBlockSize
-        - maxTxSize
-        - maxBlockHeaderSize
-        - keyDeposit
-        - poolDeposit
-        - eMax
-        - nOpt
-        - a0
-        - rho
-        - tau
-        - decentralisationParam
-        - extraEntropy
-        - protocolMajorVer
-        - protocolMinorVer
-        - minUtxo
-        - minPoolCost
-        - nonce
-        - costModels
-        - priceMem
-        - priceStep
-        - maxTxExMem
-        - maxTxExSteps
-        - maxBlockExMem
-        - maxBlockExSteps
-        - maxValSize
-        - collateralPercent
-        - maxCollateralInputs
-        - coinsPerUtxoSize
+        - parameters
     eraSummaryPayload:
       type: object
       properties:


### PR DESCRIPTION
- protocolParemeters is raw cbor now
- Transaction message is better defined; instead of string type, related fields are marked as cbor
- Corrected a mistake in the transaction message payload, resolvedInputs field is now two-dimensional array
- additionalProperties is set to false for all the message payloads